### PR TITLE
fix: Ensure sqlx reference is unambiguous

### DIFF
--- a/src/sqlite/mod.rs
+++ b/src/sqlite/mod.rs
@@ -25,9 +25,9 @@ pub(crate) async fn write_structure_sql<P: AsRef<std::path::Path>, Q: AsRef<std:
 #[cfg(feature = "sqlx")]
 mod sqlx;
 #[cfg(feature = "sqlx")]
-use sqlx::fetch_structure_sql;
+use crate::sqlite::sqlx::fetch_structure_sql;
 #[cfg(feature = "sqlx")]
-pub(crate) use sqlx::DEFAULT_CONNECTION_URL;
+pub(crate) use crate::sqlite::sqlx::DEFAULT_CONNECTION_URL;
 
 #[cfg(feature = "diesel")]
 mod diesel;


### PR DESCRIPTION
Prior to this change, I see errors such as

    error[E0659]: `sqlx` is ambiguous
      --> database-schema-0.1.1/src/sqlite/mod.rs:28:5
       |
    28 | use sqlx::fetch_structure_sql;
       |     ^^^^ ambiguous name
       |
       = note: ambiguous because of multiple potential import sources
       = note: `sqlx` could refer to a crate passed with `--extern`
       = help: use `::sqlx` to refer to this crate unambiguously
    note: `sqlx` could also refer to the module defined here