### PR TITLE
feat: allow sqlx with rustls instead of native-tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ default-members = ["."]
 resolver = "2"
 
 [features]
-default = []
-sqlx = ["dep:sqlx", "sqlx?/tls-native-tls"]
+default = ["native-tls"]
+sqlx = ["dep:sqlx"]
 diesel = ["dep:diesel", "dep:diesel_migrations"]
 macros = []
 runtime-async-std = ["sqlx?/runtime-async-std", "dep:async-std"]
@@ -27,6 +27,9 @@ runtime-tokio = ["sqlx?/runtime-tokio", "dep:tokio"]
 sqlite = ["sqlx?/sqlite", "diesel?/sqlite", "diesel_migrations?/sqlite"]
 mysql = ["sqlx?/mysql", "diesel?/mysql", "diesel_migrations?/mysql", "url", "percent-encoding"]
 postgres = ["sqlx?/postgres", "diesel?/postgres", "url", "percent-encoding"]
+
+native-tls = ["sqlx?/tls-native-tls"]
+rustls = ["sqlx?/tls-rustls"]
 
 [dependencies]
 async-std = { version = "1", optional = true } # this has to include default due to task::block_on usage


### PR DESCRIPTION
This shouldn't change the current default behaviour, but allows a user to replace `native-tls` with `rustls` if they wish.